### PR TITLE
完成Java 17 + Spring 6升级

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -1,0 +1,106 @@
+# Java 17 + Spring 6 升级说明
+
+## 升级内容
+
+### 1. Java版本升级
+- **从**: Java 8
+- **到**: Java 17
+
+### 2. Spring Framework升级
+- **从**: Spring 5.3.21
+- **到**: Spring 6.2.7 (最新稳定版)
+
+### 3. 主要依赖升级
+
+#### 核心框架
+- Spring Framework: 5.3.21 → 6.2.7
+- MyBatis: 3.5.10 → 3.5.19
+- MyBatis-Spring: 2.0.7 → 3.0.4
+
+#### Jakarta EE迁移
+- Servlet API: javax.servlet → jakarta.servlet 6.1.0
+- JSP API: javax.servlet.jsp → jakarta.servlet.jsp 4.0.0
+- JSTL: javax.servlet.jstl → org.glassfish.web.jakarta.servlet.jsp.jstl 3.0.1
+
+#### 其他依赖
+- Jackson: 2.13.3 → 2.18.2
+- MariaDB Driver: 3.0.6 → 3.5.3
+- SLF4J: 1.7.36 → 2.0.16
+- Logback: 1.2.11 → 1.5.15
+- JUnit: 4.13.2 → JUnit Jupiter 5.11.4
+
+#### 构建工具
+- Maven Compiler Plugin: 3.8.1 → 3.13.0
+- Maven WAR Plugin: 3.2.3 → 3.4.0
+- Maven Surefire Plugin: 新增 3.5.2
+
+## 重要变更
+
+### 1. 包名变更 (javax → jakarta)
+所有使用 `javax.servlet` 的代码已更新为 `jakarta.servlet`：
+- `javax.servlet.http.HttpSession` → `jakarta.servlet.http.HttpSession`
+
+### 2. Web.xml更新
+- 命名空间从 `http://xmlns.jcp.org/xml/ns/javaee` 更新为 `https://jakarta.ee/xml/ns/jakartaee`
+- 版本从 4.0 更新为 6.0
+- 添加了multipart配置支持
+
+### 3. JSP标签库更新
+所有JSP文件中的JSTL标签库URI已更新：
+- `http://java.sun.com/jsp/jstl/core` → `jakarta.tags.core`
+- `http://java.sun.com/jsp/jstl/fmt` → `jakarta.tags.fmt`
+
+### 4. 文件上传配置
+- 从 `CommonsMultipartResolver` 更改为 `StandardServletMultipartResolver`
+- 在web.xml中添加了multipart配置
+
+### 5. 测试框架
+- 从JUnit 4迁移到JUnit 5 Jupiter
+
+## 兼容性要求
+
+### 运行时要求
+- **Java**: 17或更高版本
+- **Servlet容器**: 支持Jakarta EE 9+的容器
+  - Tomcat 10.0+
+  - Jetty 11+
+  - 或其他支持Jakarta EE 9+的容器
+
+### 开发环境
+- **IDE**: 确保IDE支持Java 17和Jakarta EE
+- **Maven**: 3.6.3或更高版本
+
+## 构建和运行
+
+### 编译项目
+```bash
+mvn clean compile
+```
+
+### 运行测试
+```bash
+mvn test
+```
+
+### 打包项目
+```bash
+mvn clean package
+```
+
+### 部署
+生成的WAR文件需要部署到支持Jakarta EE 9+的Servlet容器中。
+
+## 注意事项
+
+1. **容器兼容性**: 确保使用的Servlet容器支持Jakarta EE 9+
+2. **第三方库**: 如果项目使用了其他第三方库，请确保它们也兼容Jakarta EE
+3. **IDE配置**: 更新IDE的项目设置以使用Java 17
+4. **CI/CD**: 更新构建管道以使用Java 17
+
+## 升级后的优势
+
+1. **性能提升**: Java 17和Spring 6带来的性能优化
+2. **安全性**: 最新版本的安全修复和改进
+3. **现代化**: 使用最新的Java特性和Spring功能
+4. **长期支持**: Java 17是LTS版本，Spring 6有长期支持
+5. **生态系统**: 更好的与现代Java生态系统集成

--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,16 @@
     <description>网上商城系统</description>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.3.21</spring.version>
-        <mybatis.version>3.5.10</mybatis.version>
-        <mybatis-spring.version>2.0.7</mybatis-spring.version>
-        <mariadb.version>3.0.6</mariadb.version>
-        <jackson.version>2.13.3</jackson.version>
+        <spring.version>6.2.7</spring.version>
+        <mybatis.version>3.5.19</mybatis.version>
+        <mybatis-spring.version>3.0.4</mybatis-spring.version>
+        <mariadb.version>3.5.3</mariadb.version>
+        <jackson.version>2.18.2</jackson.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <logback.version>1.5.15</logback.version>
     </properties>
 
     <dependencies>
@@ -74,42 +76,42 @@
             <version>${jackson.version}</version>
         </dependency>
 
-        <!-- Servlet API -->
+        <!-- Jakarta Servlet API (required for Spring 6) -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <version>2.2</version>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
+            <version>4.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-            <version>1.2</version>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+            <version>3.0.1</version>
         </dependency>
 
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
+            <version>${logback.version}</version>
         </dependency>
 
         <!-- Test -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -126,20 +128,25 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>17</source>
+                    <target>17</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.4.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.tomcat.maven</groupId>

--- a/src/main/java/com/shop/controller/CartController.java
+++ b/src/main/java/com/shop/controller/CartController.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 import java.util.List;
 
 /**

--- a/src/main/java/com/shop/controller/UserController.java
+++ b/src/main/java/com/shop/controller/UserController.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 
 /**
  * 用户控制器

--- a/src/main/resources/spring/spring-mvc.xml
+++ b/src/main/resources/spring/spring-mvc.xml
@@ -43,9 +43,7 @@
     </bean>
 
     <!-- 文件上传配置 -->
-    <bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
-        <property name="maxUploadSize" value="10485760" /> <!-- 10MB -->
-        <property name="defaultEncoding" value="UTF-8" />
+    <bean id="multipartResolver" class="org.springframework.web.multipart.support.StandardServletMultipartResolver">
     </bean>
 
 </beans>

--- a/src/main/webapp/WEB-INF/views/cart.jsp
+++ b/src/main/webapp/WEB-INF/views/cart.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>

--- a/src/main/webapp/WEB-INF/views/common/header.jsp
+++ b/src/main/webapp/WEB-INF/views/common/header.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
     <div class="container">

--- a/src/main/webapp/WEB-INF/views/index.jsp
+++ b/src/main/webapp/WEB-INF/views/index.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -1,5 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>

--- a/src/main/webapp/WEB-INF/views/products.jsp
+++ b/src/main/webapp/WEB-INF/views/products.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>

--- a/src/main/webapp/WEB-INF/views/register.jsp
+++ b/src/main/webapp/WEB-INF/views/register.jsp
@@ -1,5 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
-         http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
-         version="4.0">
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
     <display-name>JavaEE Shop</display-name>
 
@@ -43,6 +43,11 @@
             <param-value>classpath:spring/spring-mvc.xml</param-value>
         </init-param>
         <load-on-startup>1</load-on-startup>
+        <multipart-config>
+            <max-file-size>10485760</max-file-size> <!-- 10MB -->
+            <max-request-size>10485760</max-request-size>
+            <file-size-threshold>0</file-size-threshold>
+        </multipart-config>
     </servlet>
     <servlet-mapping>
         <servlet-name>DispatcherServlet</servlet-name>


### PR DESCRIPTION
主要变更:
- Java版本: 8 → 17
- Spring Framework: 5.3.21 → 6.2.7
- 依赖升级: MyBatis, Jackson, MariaDB驱动等
- javax → jakarta 包名迁移
- 更新web.xml到Jakarta EE 9+
- 更新JSP中的JSTL标签库URI
- 更新文件上传配置
- 添加升级说明文档

测试状态: ✅ 编译成功, ✅ 打包成功