### PR TITLE
Fix JSTL ClassNotFoundException in JDK21 + Tomcat10

### DIFF
--- a/JSTL_FIX_SUMMARY.md
+++ b/JSTL_FIX_SUMMARY.md
@@ -1,0 +1,81 @@
+# JSTL 错误修复总结
+
+## 问题描述
+
+在使用 JDK 21 + Tomcat 10 运行时，出现了以下错误：
+
+```
+java.lang.ClassNotFoundException: jakarta.servlet.jsp.jstl.core.LoopTag
+```
+
+## 问题原因
+
+该错误是由于 JSTL 依赖配置不完整导致的。虽然项目已经正确升级到了 Jakarta EE，但 JSTL 的依赖配置需要同时包含 API 和实现库。
+
+## 解决方案
+
+在 `pom.xml` 中添加了完整的 JSTL 依赖配置：
+
+### 修改前
+```xml
+<dependency>
+    <groupId>org.glassfish.web</groupId>
+    <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+    <version>3.0.1</version>
+</dependency>
+```
+
+### 修改后
+```xml
+<!-- JSTL API -->
+<dependency>
+    <groupId>jakarta.servlet.jsp.jstl</groupId>
+    <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+    <version>3.0.2</version>
+</dependency>
+<!-- JSTL Implementation -->
+<dependency>
+    <groupId>org.glassfish.web</groupId>
+    <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+    <version>3.0.1</version>
+</dependency>
+```
+
+## 修复内容
+
+1. **添加 JSTL API 依赖**: `jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.2`
+2. **保留 JSTL 实现依赖**: `org.glassfish.web:jakarta.servlet.jsp.jstl:3.0.1`
+
+## 验证结果
+
+1. **编译成功**: `mvn clean compile` 执行成功
+2. **打包成功**: `mvn clean package` 执行成功
+3. **依赖正确**: WAR 文件中包含了正确的 JSTL 库：
+   - `WEB-INF/lib/jakarta.servlet.jsp.jstl-api-3.0.2.jar`
+   - `WEB-INF/lib/jakarta.servlet.jsp.jstl-3.0.1.jar`
+4. **运行测试**: 在 Tomcat 10.1.30 + JDK 17 环境中测试，不再出现 JSTL 相关错误
+
+## 兼容性说明
+
+此修复适用于以下环境：
+- **Java**: 17 或更高版本
+- **Servlet 容器**: 支持 Jakarta EE 9+ 的容器
+  - Tomcat 10.0+
+  - Jetty 11+
+  - 或其他支持 Jakarta EE 9+ 的容器
+
+## 注意事项
+
+1. 确保 JSP 文件中使用正确的 Jakarta 标签库 URI：
+   - `<%@ taglib prefix="c" uri="jakarta.tags.core" %>`
+   - `<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>`
+
+2. 不要使用旧的 Java EE 标签库 URI：
+   - ~~`http://java.sun.com/jsp/jstl/core`~~
+   - ~~`http://java.sun.com/jsp/jstl/fmt`~~
+
+## 相关文档
+
+- [Jakarta EE 9 迁移指南](https://jakarta.ee/specifications/platform/9/platform-spec-9.html)
+- [JSTL 3.0 规范](https://jakarta.ee/specifications/tags/3.0/)
+- [Tomcat 10 迁移指南](https://tomcat.apache.org/migration-10.html)

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,13 @@
             <version>4.0.0</version>
             <scope>provided</scope>
         </dependency>
+        <!-- JSTL API -->
+        <dependency>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <!-- JSTL Implementation -->
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>jakarta.servlet.jsp.jstl</artifactId>


### PR DESCRIPTION
- Add jakarta.servlet.jsp.jstl-api dependency (3.0.2)
- Keep existing jakarta.servlet.jsp.jstl implementation (3.0.1)
- Resolves ClassNotFoundException: jakarta.servlet.jsp.jstl.core.LoopTag
- Tested with Tomcat 10.1.30 + JDK 17
- Add comprehensive fix documentation