### PR TITLE
Fix cart.jsp JSTL fn taglib import error

### DIFF
--- a/src/main/webapp/WEB-INF/views/cart.jsp
+++ b/src/main/webapp/WEB-INF/views/cart.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>


### PR DESCRIPTION
## 问题描述

修复购物车页面中的 JSTL 函数库导入错误：
- 错误信息：`属性前缀[fn]与任何导入的标记库都不对应`
- 错误位置：`/WEB-INF/views/cart.jsp` 第68行和第69行

## 解决方案

在 `cart.jsp` 文件顶部添加了缺失的 JSTL 函数库导入：
```jsp
<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
```

## 修改内容

- ✅ 添加 `fn` taglib 导入到 `cart.jsp`
- ✅ 验证其他使用 `fn:` 函数的 JSP 文件已正确导入
- ✅ 确认数据库表名 `carts` 已正确使用（无需修改）

## 测试

修复后，购物车页面中的以下功能将正常工作：
- `fn:length()` 函数用于检查商品描述长度
- `fn:substring()` 函数用于截取商品描述文本
- 商品描述超过60字符时显示省略号

## 相关文件

- `src/main/webapp/WEB-INF/views/cart.jsp` - 添加缺失的 taglib 导入

这个修复确保购物车页面能够正常显示，不再出现 taglib 相关的错误。